### PR TITLE
Fix: Create role When the domain is created

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Root domain is a system domain for over-all user-domain.
 enabled: true
 image:
     name: spaceone/spacectl
-    version: 1.9.0
+    version: 1.9.1
 domain: root
 main:
   import:
@@ -33,6 +33,14 @@ main:
       id: root_api_key
     consul_server: spaceone-consul-server
     marketplace_endpoint: grpc://repository.portal.spaceone.dev:50051
+    project_admin_policy_type: MANAGED
+    project_admin_policy_id: policy-managed-project-admin
+    project_viewer_policy_type: MANAGED
+    project_viewer_policy_id: policy-managed-project-viewer
+    domain_admin_policy_type: MANAGED
+    domain_admin_policy_id: policy-managed-domain-admin
+    domain_viewer_policy_type: MANAGED
+    domain_viewer_policy_id: policy-managed-domain-viewer
   tasks: []
 ~~~
 
@@ -62,10 +70,13 @@ main:
     domain_owner: admin
     domain_owner_password: Admin123!@#
     project_admin_policy_type: MANAGED
-    project_admin_policy_id: policy-0386cce2730b
+    project_admin_policy_id: policy-managed-project-admin
+    project_viewer_policy_type: MANAGED
+    project_viewer_policy_id: policy-managed-project-viewer
     domain_admin_policy_type: MANAGED
-    domain_admin_policy_id: policy-0386cce2730b
-
+    domain_admin_policy_id: policy-managed-domain-admin
+    domain_viewer_policy_type: MANAGED
+    domain_viewer_policy_id: policy-managed-domain-viewer
 
   tasks: []
 ~~~

--- a/deploy/helm/config/spacectl/root/root_domain.yaml
+++ b/deploy/helm/config/spacectl/root/root_domain.yaml
@@ -88,6 +88,70 @@ tasks:
       verb:
         exec: create
 
+  - name: Create project admin role
+    id: project_admin_role
+    uses: "@modules/resource"
+    spec:
+      resource_type: identity.Role
+      data:
+        name: Project Admin
+        role_type: PROJECT
+        policies:
+          - policy_type: ${{ var.project_admin_policy_type }}
+            policy_id: ${{ var.project_admin_policy_id }}
+        domain_id: ${{ tasks.domain.output.domain_id }}
+      mode: EXEC
+      verb:
+        exec: create
+
+  - name: Create project viewer role
+    id: project_admin_viewer
+    uses: "@modules/resource"
+    spec:
+      resource_type: identity.Role
+      data:
+        name: Project Viewer
+        role_type: PROJECT
+        policies:
+          - policy_type: ${{ var.project_viewer_policy_type }}
+            policy_id: ${{ var.project_viewer_policy_id }}
+        domain_id: ${{ tasks.domain.output.domain_id }}
+      mode: EXEC
+      verb:
+        exec: create
+
+  - name: Create domain admin role
+    id: domain_admin_role
+    uses: "@modules/resource"
+    spec:
+      resource_type: identity.Role
+      data:
+        name: Domain Admin
+        role_type: DOMAIN
+        policies:
+          - policy_type: ${{ var.domain_admin_policy_type }}
+            policy_id: ${{ var.domain_admin_policy_id }}
+        domain_id: ${{ tasks.domain.output.domain_id }}
+      mode: EXEC
+      verb:
+        exec: create
+
+  - name: Create domain viewer role
+    id: domain_viewer_role
+    uses: "@modules/resource"
+    spec:
+      resource_type: identity.Role
+      data:
+        name: Domain Viewer
+        role_type: DOMAIN
+        policies:
+          - policy_type: ${{ var.domain_viewer_policy_type }}
+            policy_id: ${{ var.domain_viewer_policy_id }}
+        domain_id: ${{ tasks.domain.output.domain_id }}
+      mode: EXEC
+      verb:
+        exec: create
+
   - name: Create admin user
     id: admin_user
     uses: "@modules/resource"

--- a/deploy/helm/config/spacectl/user/local_domain.yaml
+++ b/deploy/helm/config/spacectl/user/local_domain.yaml
@@ -60,8 +60,24 @@ tasks:
         name: Project Admin
         role_type: PROJECT
         policies:
-          - policy_type: ${{ var.project_admin_policy_type }}
+          - policy_type: MANAGED
             policy_id: ${{ var.project_admin_policy_id }}
+        domain_id: ${{ tasks.domain.output.domain_id }}
+      mode: EXEC
+      verb:
+        exec: create
+
+  - name: Create project viewer role
+    id: project_admin_viewer
+    uses: "@modules/resource"
+    spec:
+      resource_type: identity.Role
+      data:
+        name: Project Viewer
+        role_type: PROJECT
+        policies:
+          - policy_type: MANAGED
+            policy_id: ${{ var.project_viewer_policy_id }}
         domain_id: ${{ tasks.domain.output.domain_id }}
       mode: EXEC
       verb:
@@ -76,8 +92,24 @@ tasks:
         name: Domain Admin
         role_type: DOMAIN
         policies:
-          - policy_type: ${{ var.domain_admin_policy_type }}
+          - policy_type: MANAGED
             policy_id: ${{ var.domain_admin_policy_id }}
+        domain_id: ${{ tasks.domain.output.domain_id }}
+      mode: EXEC
+      verb:
+        exec: create
+
+  - name: Create domain viewer role
+    id: domain_viewer_role
+    uses: "@modules/resource"
+    spec:
+      resource_type: identity.Role
+      data:
+        name: Domain Viewer
+        role_type: DOMAIN
+        policies:
+          - policy_type: MANAGED
+            policy_id: ${{ var.domain_viewer_policy_id }}
         domain_id: ${{ tasks.domain.output.domain_id }}
       mode: EXEC
       verb:

--- a/deploy/helm/values.yaml
+++ b/deploy/helm/values.yaml
@@ -39,6 +39,14 @@ skip_health_check: false
 #      id: root_api_key
 #    consul_server: spaceone-consul-server
 #    marketplace_endpoint: grpc://repository.portal.spaceone.dev:50051
+#    project_admin_policy_type: MANAGED
+#    project_admin_policy_id: policy-managed-project-admin
+#    project_viewer_policy_type: MANAGED
+#    project_viewer_policy_id: policy-managed-project-viewer
+#    domain_admin_policy_type: MANAGED
+#    domain_admin_policy_id: policy-managed-domain-admin
+#    domain_viewer_policy_type: MANAGED
+#    domain_viewer_policy_id: policy-managed-domain-viewer
 #  tasks: []
 
 ###################
@@ -59,10 +67,17 @@ skip_health_check: false
 #    default_timezone: Asia/Seoul
 #    domain_owner: admin
 #    domain_owner_password: Admin123!@#
+#    project_admin_policy_id: policy-managed-project-admin
+#    project_viewer_policy_id: policy-managed-project-viewer
+#    domain_admin_policy_id: policy-managed-domain-admin
+#    domain_viewer_policy_id: policy-managed-domain-viewer
 #    project_admin_policy_type: MANAGED
-#    project_admin_policy_id: policy-0386cce2730b
+#    project_admin_policy_id: policy-managed-project-admin
+#    project_viewer_policy_type: MANAGED
+#    project_viewer_policy_id: policy-managed-project-viewer
 #    domain_admin_policy_type: MANAGED
-#    domain_admin_policy_id: policy-0386cce2730b
-#
+#    domain_admin_policy_id: policy-managed-domain-admin
+#    domain_viewer_policy_type: MANAGED
+#    domain_viewer_policy_id: policy-managed-domain-viewer
 #
 #  tasks: []


### PR DESCRIPTION
## description
Add roles in ROOT domain  https://github.com/spaceone-dev/spaceone-initializer/issues/10

> ROOT domain does not initialize roles like Admin role and Project role.
> Add role in script.